### PR TITLE
Improve handling of cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # where 
 
-Brett Terpstra 2015, WTF license <http://wtflicense.com/>
+Brett Terpstra 2015, WTF license <http://www.wtfpl.net/>
 
 ## Description
 

--- a/_where.bash
+++ b/_where.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 source $(dirname $BASH_SOURCE)/common.bash
-# where 1.0.5 by Brett Terpstra 2015, WTF license <http://wtflicense.com/>
+# where 1.0.5 by Brett Terpstra 2015, WTF license <http://www.wtfpl.net/>
 
 #### Description
 # For people who spread bash functions and aliases across multiple sourced

--- a/_where.bash
+++ b/_where.bash
@@ -157,7 +157,7 @@ _where_reset() {
     local dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || exit 1
     trap "rm -f -- '$dbtmp'" EXIT
     awk '!/^[0-9]+$/{print}' "$WHERE_FUNCTIONS_FROM_DB" > "$dbtmp"
-    mv "$dbtmp" "$WHERE_FUNCTIONS_FROM_DB"
+    mv -f "$dbtmp" "$WHERE_FUNCTIONS_FROM_DB"
   fi
 }
 
@@ -166,7 +166,7 @@ _where_set_update() {
   trap "rm -f -- '$dbtmp'" EXIT
   date '+%s' > "$dbtmp"
   awk '!/^[0-9]+$/{print}' "$WHERE_FUNCTIONS_FROM_DB" >> "$dbtmp"
-  mv "$dbtmp" "$WHERE_FUNCTIONS_FROM_DB"
+  mv -f "$dbtmp" "$WHERE_FUNCTIONS_FROM_DB"
 }
 
 # If this is the first time _where has been sourced in this session, expire the db
@@ -369,7 +369,7 @@ _where_clean() {
     t=$(mktemp -t where_clean.XXXXXX)
     trap "rm -f -- '$t'" EXIT
     grep -v "^_where_from \$BASH_SOURCE" $f > $t
-    mv "$t" "$f"
+    mv -f "$t" "$f"
     trap - EXIT
   done
   >&2 echo -ne "\033[K"

--- a/_where.bash
+++ b/_where.bash
@@ -149,12 +149,13 @@ _where_db_fresh() {
 }
 
 _where_reset() {
+  local dbtmp
   if [[ $1 == "hard" ]]; then
     __color_out "%b_white%where: %b_red%Clearing function index"
     echo -n > "$WHERE_FUNCTIONS_FROM_DB"
   else
     __color_out "%b_white%where: %b_red%Resetting function index"
-    local dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || return
+    dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || return
     trap "rm -f -- '$dbtmp'" RETURN
     awk '!/^[0-9]+$/{print}' "$WHERE_FUNCTIONS_FROM_DB" > "$dbtmp"
     mv -f "$dbtmp" "$WHERE_FUNCTIONS_FROM_DB"
@@ -163,7 +164,8 @@ _where_reset() {
 }
 
 _where_set_update() {
-  local dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || return
+  local dbtmp
+  dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || return
   trap "rm -f -- '$dbtmp'" RETURN
   date '+%s' > "$dbtmp"
   awk '!/^[0-9]+$/{print}' "$WHERE_FUNCTIONS_FROM_DB" >> "$dbtmp"
@@ -189,14 +191,14 @@ _where_to_regex ()
 #   func_or_alias_name:(function|alias):path_to_source
 # @param 1: (Required) single file path to parse and index
 _where_from() {
-  local needle
+  local needle dbtmp
   local srcfile=$1
 
   [[ ! -e $srcfile ]] && return 1
   touch $WHERE_FUNCTIONS_FROM_DB
   >&2 __color_out -n "\033[K%white%Indexing %red%$1...\r"
   # create a temp file and clean on return
-  local dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || return
+  dbtmp=$(mktemp -t WHERE_DB.XXXXXX) || return
   trap "rm -f -- '$dbtmp'" RETURN
 
   IFS=$'\n' cat "$srcfile" | awk '/^(function )?[_[:alnum:]]+ *\(\)/{gsub(/(function | *\(.+)/,"");print $1":"NR}' | while read f

--- a/_where.bash
+++ b/_where.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 source $(dirname $BASH_SOURCE)/common.bash
-# where 1.0.4 by Brett Terpstra 2015, WTF license <http://wtflicense.com/>
+# where 1.0.5 by Brett Terpstra 2015, WTF license <http://wtflicense.com/>
 
 #### Description
 # For people who spread bash functions and aliases across multiple sourced
@@ -393,21 +393,16 @@ alias where*="where -a"
 
 # hook source builtin to index source bash files
 source() {
-  if [[ -z $WHERE_HOOK_SOURCE || $WHERE_HOOK_SOURCE == false || $WHERE_DB_EXPIRED == false ]]; then
-    for f in $@; do
-      builtin source $f
-    done
-  else
-    for f in $@; do
-      builtin source $f
+  builtin source $@
+  [[ $WHERE_HOOK_SOURCE == true && $WHERE_DB_EXPIRED == true ]] || return 0
 
-      if [[ $f =~ \.(ba)?sh$ && $(grep -cE "^_where_from \$BASH_SOURCE" $f) == 0 ]]; then
-        for f in $@; do
-          _where_from $f
-        done
-      fi
-    done
-  fi
+  for f in $@; do
+    if [[ $f =~ \.(ba)?sh$ && $(grep -cE "^_where_from \$BASH_SOURCE" $f) == 0 ]]; then
+      for f in $@; do
+        _where_from $f
+      done
+    fi
+  done
 }
 
 # Add functions from self to index

--- a/_where.bash
+++ b/_where.bash
@@ -392,18 +392,21 @@ alias where?="where -k"
 alias where*="where -a"
 
 # hook source builtin to index source bash files
-source() {
-  builtin source $@
-  [[ $WHERE_HOOK_SOURCE == true && $WHERE_DB_EXPIRED == true ]] || return 0
+if [[ ${WHERE_HOOK_SOURCE:-false} == true ]]
+then
+  function source() {
+    builtin source $@
+    [[ ${WHERE_HOOK_SOURCE:-} == true && $WHERE_DB_EXPIRED == true ]] || return 0
 
-  for f in $@; do
-    if [[ $f =~ \.(ba)?sh$ && $(grep -cE "^_where_from \$BASH_SOURCE" $f) == 0 ]]; then
-      for f in $@; do
-        _where_from $f
-      done
-    fi
-  done
-}
+    for f in $@; do
+      if [[ $f =~ \.(ba)?sh$ && $(grep -cE "^_where_from \$BASH_SOURCE" $f) == 0 ]]; then
+        for f in $@; do
+          _where_from $f
+        done
+      fi
+    done
+  }
+fi
 
 # Add functions from self to index
 _where_from $BASH_SOURCE


### PR DESCRIPTION
Some minor fixes to handling of `~/.where_functions`, including improved `trap` usage and error handling for `mktemp`.

Alsö, update the URL for the WTF license and close #1.

(This PR assumes/includes/resolves #3.)