### PR TITLE
Use XDG location and independent invocation

### DIFF
--- a/_where.bash
+++ b/_where.bash
@@ -108,7 +108,7 @@ source "${BASH_SOURCE%/*}/common.bash"
 #
 #### End
 
-_debug() {
+_where_debug() {
   "${DEBUG:-false}" && __color_out "%b_white%where: %purple%$*"
 }
 
@@ -119,26 +119,26 @@ _where_updated() {
 # Check the last index date, only update based on WHERE_EXPIRATION
 _where_db_fresh() {
   if [[ ! -e $WHERE_FUNCTIONS_FROM_DB || $(( $(wc -l < "$WHERE_FUNCTIONS_FROM_DB")<=1 )) == 1 || ${WHERE_EXPIRATION:-0} == 0 ]]; then
-    _debug "no database, no expiration set, or expiration 0"
+    _where_debug "no database, no expiration set, or expiration 0"
     WHERE_DB_EXPIRED=true
     return 1
   fi
   local last_update=$(_where_updated)
   if [[ $last_update == "" ]]; then
-    _debug "No timestamp in index"
+    _where_debug "No timestamp in index"
     WHERE_DB_EXPIRED=true
     return 1
   fi
 
-  _debug "last update: `date -r $last_update`"
-  _debug "time since update: $(( $(date '+%s')-$last_update ))"
+  _where_debug "last update: `date -r $last_update`"
+  _where_debug "time since update: $(( $(date '+%s')-$last_update ))"
   if [ $(( $(date '+%s')-$last_update )) -ge ${WHERE_EXPIRATION:-0} ]; then
-    _debug "%red%Expired (threshhold ${WHERE_EXPIRATION:-})"
+    _where_debug "%red%Expired (threshhold ${WHERE_EXPIRATION:-})"
     WHERE_DB_EXPIRED=true
     return 1
   fi
   WHERE_DB_EXPIRED=false
-  _debug "%green%database fresh"
+  _where_debug "%green%database fresh"
   return 0
 }
 
@@ -301,7 +301,7 @@ ENDOPTIONSHELP
     fi
   fi
 
-  _debug "Searching for '$needle'"
+  _where_debug "Searching for '$needle'"
 
   if $fuzzy || $apropos; then
     if [[ $(grep -Ec $needle $WHERE_FUNCTIONS_FROM_DB) > 0 ]]; then

--- a/_where.bash
+++ b/_where.bash
@@ -108,11 +108,6 @@ source $(dirname $BASH_SOURCE)/common.bash
 #
 #### End
 DEBUG=false
-## Initialization
-# If no WHERE_FUNCTIONS_FROM_DB env var is set, use default
-[[ -z $WHERE_FUNCTIONS_FROM_DB ]] && export WHERE_FUNCTIONS_FROM_DB="$HOME/.where_functions"
-
-touch $WHERE_FUNCTIONS_FROM_DB
 
 _debug() {
   $DEBUG && __color_out "%b_white%where: %purple%$*"
@@ -172,9 +167,6 @@ _where_set_update() {
   mv -f "$dbtmp" "$WHERE_FUNCTIONS_FROM_DB"
   trap - RETURN
 }
-
-# If this is the first time _where has been sourced in this session, expire the db
-_where_db_fresh || _where_reset
 
 # Convert a string into a fuzzy-match regular expression for _where
 # Separates each character and adds ".*" after, removing spaces
@@ -392,6 +384,12 @@ _where_add() {
   >&2 echo -ne "\033[K"
 }
 
+## Initialization
+# If no WHERE_FUNCTIONS_FROM_DB env var is set, use default
+[[ -z $WHERE_FUNCTIONS_FROM_DB ]] && export WHERE_FUNCTIONS_FROM_DB="$HOME/.where_functions"
+
+touch $WHERE_FUNCTIONS_FROM_DB
+
 # Aliases for apropos and fuzzy search
 alias where?="where -k"
 alias where*="where -a"
@@ -412,6 +410,9 @@ then
     done
   }
 fi
+
+# If this is the first time _where has been sourced in this session, expire the db
+_where_db_fresh || _where_reset
 
 # Add functions from self to index
 _where_from $BASH_SOURCE

--- a/_where.bash
+++ b/_where.bash
@@ -385,10 +385,12 @@ _where_add() {
 
 ## Initialization
 # If no WHERE_FUNCTIONS_FROM_DB env var is set, use default
-: ${WHERE_FUNCTIONS_FROM_DB:="$HOME/.where_functions"}
+: "${WHERE_FUNCTIONS_FROM_DB:=${XDG_CACHE_HOME:-$HOME/.where_functions}${XDG_CACHE_HOME:+/where/functionsdb}}"
 
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]
 then # We are being sourced.
+
+	mkdir -p "${WHERE_FUNCTIONS_FROM_DB%/*}"
 
 	# Aliases for apropos and fuzzy search
 	alias where?="where -k"


### PR DESCRIPTION
A few improvements including the ability to run the script without sourcing it (and it will read from already-existing functions cache file), storing the functions cache in `$XDG_CACHE_HOME` (if defined), and a whole bunch of parameter quoting.

(This PR includes/assumes/resolves #3 and includes/assumes/resolves #4.)